### PR TITLE
Add package.json for mip.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+    "urls": [
+      ["phew/__init__.py", "github:pimoroni/pms5003/pms5003/__init__.py"]
+    ],
+    "deps": [],
+    "version": "0.0.7"
+  }


### PR DESCRIPTION
Requested for "phew" by @jimmo https://github.com/orgs/micropython/discussions/10546#discussioncomment-4762921

Makes sense here too. I think.

Added as per https://docs.micropython.org/en/latest/reference/packages.html#writing-publishing-packages

@jimmo how does `mip` handle versioning for files hosted in a GitHub repository? Our normal procedure would be to bump the version, publish to PyPi, tag the repository with the version number and create a "release" on GitHub. This gives a fixed snapshot of the repository state at that version.

From what I can tell looking at mip source and the fixed URLs in the package.json, there's no facility to refer to a specific tag?